### PR TITLE
Adopt the Amazon Open Source Code of Conduct.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# Ion Fusion Code of Conduct
+
+This code of conduct provides guidance on participation in our open source community, outlines the
+process for reporting unacceptable behavior, and documents consequences for unacceptable behavior.
+As an organization and community, we are committed to providing an inclusive environment for
+everyone.
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our communities a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or
+sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to open, welcoming, diverse, inclusive, and
+healthy communities.
+
+We believe peer to peer discussions, feedback, and corrections can help build a stronger, safer, and
+more welcoming community. If you see someone behaving disrespectfully, you are encouraged to
+respectfully discourage them from such behavior. Expect that others in the community wish to help
+keep the community respectful and welcome your input in doing so. We seek to resolve conflicts
+peacefully and in a manner that is positive for the community.
+
+## Our Standards
+
+As contributors, members, or bystanders we each individually have the responsibility to behave
+professionally and respectfully at all times. We are kind to others and careful in the words that we
+choose.
+
+Examples of behavior that contributes to a positive environment for our communities include, but are
+not limited to:
+
+* Demonstrating empathy and kindness towards other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive and actionable feedback
+* Accepting accountability and responsibility, apologizing to those affected by our mistakes, and
+  learning from the experience
+* Prioritizing the health and well-being of the overall community over individual actions
+
+Examples of unacceptable behaviors include, but are not limited to:
+
+* The use of violent threats, abusive, insulting, discriminatory, or derogatory content
+* Offensive comments related to age, body size, visible or invisible disability, ethnicity, sex
+  characteristics, gender identity and expression, level of experience, education, socio-economic
+  status, nationality, personal appearance, race, caste, color, religion, or sexual identity and
+  orientation
+* The use of sexualized language or imagery and sexual attention or advances of any kind
+* Public or private harassment including, but not limited to, intimidation, stalking, repeated
+  inappropriate social contact, and unwanted communication. In general, if someone asks you to stop,
+  then stop.
+* Berating others because you are not getting what you want. It is not acceptable to demand
+  immediate resolution of your issues, to derail other issues “just to make your point”, or to use
+  personal insults when you feel like you are being ignored.
+* Publishing private information, such as physical or electronic address, without explicit
+  permission
+* Advocating for or encouraging any of the above behaviors.
+
+## Enforcement Responsibilities
+
+Community maintainers are responsible for clarifying and enforcing our standards of acceptable
+behavior and will take appropriate and fair corrective action in response to any behavior that they
+deem inappropriate, threatening, offensive, or harmful.
+
+Community maintainers have the right and responsibility to remove, edit, decline, or reject
+comments, commits, code, wiki edits, issues, pull requests, and other contributions that are not
+aligned to this Code of Conduct, and will communicate reasons for moderation decisions when
+appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is
+representing the community. Examples of representing our community include using official e-mail
+address, posting via an official social media account, or acting as an appointed representative at
+an online or offline event.
+
+## Enforcement Guidelines
+
+Community maintainers will follow these Enforcement Guidelines in determining the consequences for
+any action they deem in violation of this Code of Conduct:
+
+1. **Correction**
+    * **Community Impact:** Use of inappropriate language or other behavior deemed unprofessional or
+      unwelcome in the community.
+    * **Consequence:** A private, written warning, providing clarity around the nature of the
+      violation and an explanation of why the behavior was inappropriate. A public apology may be
+      requested.
+
+2. **Warning**
+    * **Community Impact:** A violation through a single incident or series of actions.
+    * **Consequence:** A written warning with consequences for continued behavior. No interaction
+      with the people involved, including unsolicited interaction with those enforcing the Code of
+      Conduct, for a specified period of time. This includes avoiding interactions in community
+      spaces as well as external channels like social media. Violating these terms may lead to a
+      temporary or permanent ban.
+
+3. **Temporary Ban**
+    * **Community Impact:** A serious violation of community standards, including sustained
+      inappropriate behavior.
+    * **Consequence:** A temporary ban from any sort of interaction or public communication with the
+      community for a specified period of time. No public or private interaction with the people
+      involved, including unsolicited interaction with those enforcing the Code of Conduct, is
+      allowed during this period. Violating these terms may lead to a permanent ban.
+
+4. **Permanent Ban**
+    * **Community Impact:** Demonstrating a pattern of violation of community standards, including
+      sustained inappropriate behavior, harassment of an individual, or aggression toward or
+      disparagement of classes of individuals.
+    * **Consequence:** A permanent ban from any sort of public interaction within the community.
+
+## Reporting Code of Conduct Issues
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting
+<todd@toddjonker.net>. All complaints will be reviewed and investigated promptly and fairly. Any
+member of the community may report a Code of Conduct issue, even if they were not the target of
+unacceptable behavior or harassment. Reports will be kept private and secure.
+
+## Attribution
+
+This code of conduct is based on the
+[Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct)
+and includes material from the
+[Contributor Covenant version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/),
+the [Apache Code of Conduct](https://www.apache.org/foundation/policies/conduct), the
+[Indieweb Code of Conduct](https://indieweb.org/code-of-conduct), and the
+[Maintainer's Guide to Staying Positive](https://github.com/jonschlinkert/maintainers-guide-to-staying-positive)
+(CC-BY-4.0, [Jon Schlinkert](https://github.com/jonschlinkert)).
+
+Accordingly, this document itself is licensed under
+[CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/), but if you choose to use it, please
+remove and/or replace references to this project.


### PR DESCRIPTION
Content copy-pasted from https://aws.github.io/code-of-conduct and manually formatted.  The only changes are to eliminate references to Amazon.

I picked this CoC after reviewing quite a few variants of the Contributor Covenant.  On the whole I liked the changes Amazon made, so I took this as a reasonable starting point.

Part of https://github.com/ion-fusion/fusion-java/issues/5

Note that this CoC will become the default for all repositories within the org.